### PR TITLE
Mention dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ An Alfred workflow to convert html in your clipboard to haml
 
 ### Install
 
-Download and install the latest version from the [release page](https://github.com/adambutler/Alfred-Workflow-html2haml/releases).
+Ensure you have `ruby` and the `html2haml` gem installed.
+
+Download and install the latest workflow version from the [release page](https://github.com/adambutler/Alfred-Workflow-html2haml/releases).
 
 ### Usage
 


### PR DESCRIPTION
I know it's fairly obvious that you'd need `html2haml` installed, but better to explicitly state it.
